### PR TITLE
chore(ci): bump github-stats-card to v1.1.4

### DIFF
--- a/.github/workflows/refresh-stats.yml
+++ b/.github/workflows/refresh-stats.yml
@@ -22,7 +22,7 @@ jobs:
           git pull origin main
       - name: Generate GitHub Stats - Dark
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: stats
           username: stn1slv
@@ -36,7 +36,7 @@ jobs:
       
       - name: Generate GitHub Stats - Light
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: stats
           username: stn1slv
@@ -50,7 +50,7 @@ jobs:
       
       - name: Generate GitHub Stats - Default
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: stats
           username: stn1slv
@@ -61,7 +61,7 @@ jobs:
 
       - name: Generate Top Contributions - Dark
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: contrib
           username: stn1slv
@@ -74,7 +74,7 @@ jobs:
           
       - name: Generate Top Contributions - Light
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: contrib
           username: stn1slv
@@ -87,7 +87,7 @@ jobs:
           
       - name: Generate Top Contributions - Default
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: contrib
           username: stn1slv
@@ -98,7 +98,7 @@ jobs:
 
       - name: Generate Top Languages - Dark
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: top-langs
           username: stn1slv
@@ -113,7 +113,7 @@ jobs:
       
       - name: Generate Top Languages - Light
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: top-langs
           username: stn1slv
@@ -128,7 +128,7 @@ jobs:
       
       - name: Generate Top Languages - Default
         continue-on-error: true
-        uses: stn1slv/github-stats-card@v1.1.3
+        uses: stn1slv/github-stats-card@v1.1.4
         with:
           card-type: top-langs
           username: stn1slv


### PR DESCRIPTION
## Summary
- update `.github/workflows/refresh-stats.yml` to use `stn1slv/github-stats-card@v1.1.4`
- keep all existing workflow inputs unchanged

## Validation
- verified there are no remaining `v1.1.3` references in the workflow
- confirmed the workflow file has no editor-reported YAML errors

## Testing
- no automated tests exist for this workflow-only change